### PR TITLE
strong transitioning delegate reference

### DIFF
--- a/test/BTViewController.m
+++ b/test/BTViewController.m
@@ -12,6 +12,8 @@
 
 
 @interface BTViewController ()
+
+@property (strong, nonatomic) BTSlideInteractor *interactor;
 @end
 
 
@@ -32,12 +34,12 @@
 
 - (IBAction)showModalButtonWasTouched:(id)sender
 {
-    BTSlideInteractor *interactor = [[BTSlideInteractor alloc] init];
-    interactor.presenting = YES;
+    self.interactor = [[BTSlideInteractor alloc] init];
+    self.interactor.presenting = YES;
     
     BTModalViewController *modalController = [self.storyboard instantiateViewControllerWithIdentifier:@"ModalViewController"];
     modalController.modalPresentationStyle = UIModalPresentationCustom;
-    modalController.transitioningDelegate = interactor;
+    modalController.transitioningDelegate = self.interactor;
     [self presentViewController:modalController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
Running the example from your blog post resulted in an EXEC_BAD_ACCESS when dismissing the View Controller. This change ensures that the delegate is still available when dismissViewController is being called.
